### PR TITLE
jsonize configmap and delete extra requests

### DIFF
--- a/generator/src/pkg/generate/generate.go
+++ b/generator/src/pkg/generate/generate.go
@@ -71,7 +71,6 @@ type Endpoints struct {
 	NetworkConsumption float64          `json:"networkConsumption"`
 	MemoryConsumption  float64          `json:"memoryConsumption"`
 	CalledServices     []CalledServices `json:"calledServices"`
-	Requests           string           `json:"requests"`
 }
 type ResourceLimits struct {
 	Cpu    string `json:"cpu"`
@@ -185,7 +184,7 @@ func Create(config Config, readinessProbe int, clusters []string) {
 		}
 
 		serv_endpoints := []Endpoints(config.Services[i].Endpoints)
-		serv_ep_json, err := json.Marshal(serv_endpoints)
+		serv_ep_json, err := json.Marshal(map[string][]Endpoints{"endpoints": serv_endpoints})
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
This will jsonize the config format and delete extra `requests` field in the endpoint. 
It closes #30.

As we discussed, the configmap format was a list, by merging this PR, it will be a complete json and the extra `requests` is deleted as below:
```
{"endpoints":[{"name":"/end-1","cpuConsumption":0,"networkConsumption":0,"memoryConsumption":0,"calledServices":[{"cluster":"cluster-1","service":"service-2","endpoint":"/end-2","protocol":"","traffic_forward_ratio":1,"requests":"asynchronous"}]}]}
```

The complete output for configmap is like:
```
apiVersion: v1
kind: ConfigMap
metadata:
    name: config-service-1
    labels:
        name: config-service-1
        version: cluster-1
    namespace: ns-1
data:
    conf.json: '{"endpoints":[{"name":"/end-1","cpuConsumption":0,"networkConsumption":0,"memoryConsumption":0,"calledServices":[{"cluster":"cluster-1","service":"service-2","endpoint":"/end-2","protocol":"","traffic_forward_ratio":1,"requests":"asynchronous"}]}]}'
```

