### PR TITLE
optional nodename for deployment affintiy

### DIFF
--- a/generator/src/pkg/generate/generate.go
+++ b/generator/src/pkg/generate/generate.go
@@ -226,7 +226,7 @@ func Create(config Config, readinessProbe int, clusters []string) {
 			configmap = s.CreateConfig("config-"+serv, "config-"+serv, c_id, namespace, string(serv_json), proto_temp_filled)
 			appendManifest(configmap)
 
-			deployment := s.CreateDeploymentWithAffinity(serv, serv, c_id, replicaNumber, serv, c_id, namespace,
+			deployment := s.CreateDeployment(serv, serv, c_id, replicaNumber, serv, c_id, namespace,
 				defaultPort, imageName, imageURL, volumePath, volumeName, "config-"+serv, readinessProbe,
 				resources.Requests.Cpu, resources.Requests.Memory, resources.Limits.Cpu, resources.Limits.Memory, nodeAffinity, protocol)
 			appendManifest(deployment)

--- a/generator/src/pkg/generate/generate.go
+++ b/generator/src/pkg/generate/generate.go
@@ -59,18 +59,18 @@ var (
 
 type CalledServices struct {
 	Service             string  `json:"service"`
-	Port           			string	`json:"port"`
+	Port                string  `json:"port"`
 	Endpoint            string  `json:"endpoint"`
 	Protocol            string  `json:"protocol"`
 	TrafficForwardRatio float32 `json:"traffic_forward_ratio"`
 }
 type Endpoints struct {
 	Name               string           `json:"name"`
-	Protocol           string						`json:"protocol"`
+	Protocol           string           `json:"protocol"`
 	CpuConsumption     float64          `json:"cpu_consumption"`
 	NetworkConsumption float64          `json:"network_consumption"`
 	MemoryConsumption  float64          `json:"memory_consumption"`
-	ForwardRequests    string  					`json:"forward_requests"`
+	ForwardRequests    string           `json:"forward_requests"`
 	CalledServices     []CalledServices `json:"called_services"`
 }
 type ResourceLimits struct {
@@ -89,14 +89,14 @@ type Services struct {
 	Name      string      `json:"name"`
 	Clusters  []Clusters  `json:"clusters"`
 	Resources Resources   `json:"resources"`
-	Processes	int					`json:"processes"`
+	Processes int         `json:"processes"`
 	Endpoints []Endpoints `json:"endpoints"`
 }
 
 type Clusters struct {
 	Cluster   string `json:"cluster"`
 	Namespace string `json:"namespace"`
-	Node      string `json:"node"`
+	Node      string `json:"node,omitempty"`
 }
 
 type Latencies struct {
@@ -111,8 +111,8 @@ type Config struct {
 }
 
 type ConfigMap struct {
-	Processes	int					`json:"processes"`
-	Endpoints []Endpoints	`json:"endpoints"`
+	Processes int         `json:"processes"`
+	Endpoints []Endpoints `json:"endpoints"`
 }
 
 // the slices to store services, cluster and endpoints for counting and printing
@@ -218,18 +218,11 @@ func Create(config Config, readinessProbe int, clusters []string) {
 			}
 			configmap = s.CreateConfig("config-"+serv, "config-"+serv, c_id, namespace, string(serv_json))
 			appendManifest(configmap)
-			if nodeAffinity == "" {
-				deployment := s.CreateDeployment(serv, serv, c_id, replicaNumber, serv, c_id, namespace,
-					defaultPort, imageName, imageURL, volumePath, volumeName, "config-"+serv, readinessProbe,
-					resources.Requests.Cpu, resources.Requests.Memory, resources.Limits.Cpu, resources.Limits.Memory)
 
-				appendManifest(deployment)
-			} else {
-				deployment := s.CreateDeploymentWithAffinity(serv, serv, c_id, replicaNumber, serv, c_id, namespace,
-					defaultPort, imageName, imageURL, volumePath, volumeName, "config-"+serv, readinessProbe,
-					resources.Requests.Cpu, resources.Requests.Memory, resources.Limits.Cpu, resources.Limits.Memory, nodeAffinity)
-				appendManifest(deployment)
-			}
+			deployment := s.CreateDeploymentWithAffinity(serv, serv, c_id, replicaNumber, serv, c_id, namespace,
+				defaultPort, imageName, imageURL, volumePath, volumeName, "config-"+serv, readinessProbe,
+				resources.Requests.Cpu, resources.Requests.Memory, resources.Limits.Cpu, resources.Limits.Memory, nodeAffinity)
+			appendManifest(deployment)
 
 			service = s.CreateService(serv, serv, protocol, uri, c_id, namespace, defaultExtPort, defaultPort)
 			appendManifest(service)

--- a/generator/src/pkg/model/deployment.go
+++ b/generator/src/pkg/model/deployment.go
@@ -41,50 +41,13 @@ type DeploymentInstance struct {
 					Cluster string `yaml:"version"`
 				} `yaml:"labels"`
 			} `yaml:"metadata"`
-			Spec SpecInstance `yaml:"spec"`
+			Spec specInstance `yaml:"spec"`
 		} `yaml:"template"`
 	} `yaml:"spec"`
 }
 
-type DeploymentInstanceWithAffinity struct {
-	APIVersion string `yaml:"apiVersion"`
-	Kind       string `yaml:"kind"`
-	Metadata   struct {
-		Name      string `yaml:"name"`
-		Namespace string `yaml:"namespace"`
-		Labels    struct {
-			App     string `yaml:"app,omitempty"`
-			Cluster string `yaml:"version,omitempty"`
-		} ` yaml:"labels"`
-	} `yaml:"metadata"`
-	Spec struct {
-		Selector struct {
-			MatchLabels struct {
-				App     string `yaml:"app"`
-				Cluster string `yaml:"version"`
-			} `yaml:"matchLabels"`
-		} `yaml:"selector"`
-		Replicas int `yaml:"replicas"`
-		Template struct {
-			Metadata struct {
-				Labels struct {
-					App     string `yaml:"app"`
-					Cluster string `yaml:"version"`
-				} `yaml:"labels"`
-			} `yaml:"metadata"`
-			Spec specInstanceWithAffinity `yaml:"spec"`
-		} `yaml:"template"`
-	} `yaml:"spec"`
-}
-
-type SpecInstance struct {
-	ServiceAccount string              `yaml:"serviceAccountName,omitempty"`
-	Containers     []ContainerInstance `yaml:"containers"`
-	Volumes        []VolumeInstance    `yaml:"volumes"`
-}
-
-type specInstanceWithAffinity struct {
-	NodeName       string              `yaml:"nodeName"`
+type specInstance struct {
+	NodeName       string              `yaml:"nodeName,omitempty"`
 	ServiceAccount string              `yaml:"serviceAccountName,omitempty"`
 	Containers     []ContainerInstance `yaml:"containers"`
 	Volumes        []VolumeInstance    `yaml:"volumes"`

--- a/generator/src/pkg/service/util.go
+++ b/generator/src/pkg/service/util.go
@@ -20,62 +20,12 @@ import (
 	"fmt"
 )
 
-func CreateDeployment(metadataName, selectorAppName, selectorClusterName string, numberOfReplicas int,
-	templateAppLabel, templateClusterLabel, namespace string, containerPort int, containerName, containerImage,
-	mountPath string, volumeName, configMapName string, readinessProbe int, requestCPU, requestMemory, limitCPU,
-	limitMemory string) (deploymentInstance model.DeploymentInstance) {
-
-	var deployment model.DeploymentInstance
-	var containerInstance model.ContainerInstance
-
-	var containerPortInstance model.ContainerPortInstance
-	var containerVolume model.ContainerVolumeInstance
-	var volumeInstance model.VolumeInstance
-
-	containerPortInstance.ContainerPort = containerPort
-	volumeInstance.Name = volumeName
-	volumeInstance.ConfigMap.Name = configMapName
-
-	containerVolume.MountName = volumeName
-	containerVolume.MountPath = mountPath
-
-	containerInstance.Volumes = append(containerInstance.Volumes, containerVolume)
-	containerInstance.Ports = append(containerInstance.Ports, containerPortInstance)
-	containerInstance.Name = containerName
-	containerInstance.Image = containerImage
-	containerInstance.ImagePullPolicy = "Never"
-	containerInstance.ReadinessProbe.HttpGet.Path = "/"
-	containerInstance.ReadinessProbe.HttpGet.Port = containerPort
-	containerInstance.ReadinessProbe.InitialDelaySeconds = readinessProbe
-	containerInstance.ReadinessProbe.PeriodSeconds = 1
-	containerInstance.Resources.ResourceRequests.Cpu = requestCPU
-	containerInstance.Resources.ResourceRequests.Memory = requestMemory
-	containerInstance.Resources.ResourceLimits.Cpu = limitCPU
-	containerInstance.Resources.ResourceLimits.Memory = limitMemory
-
-	deployment.APIVersion = "apps/v1"
-	deployment.Kind = "Deployment"
-	deployment.Metadata.Name = metadataName
-	deployment.Metadata.Namespace = namespace
-	deployment.Metadata.Labels.Cluster = templateClusterLabel
-	deployment.Spec.Selector.MatchLabels.App = selectorAppName
-	deployment.Spec.Selector.MatchLabels.Cluster = selectorClusterName
-	deployment.Spec.Replicas = numberOfReplicas
-	deployment.Spec.Template.Metadata.Labels.App = templateAppLabel
-	deployment.Spec.Template.Metadata.Labels.Cluster = templateClusterLabel
-	deployment.Spec.Template.Spec.Containers = append(deployment.Spec.Template.Spec.Containers, containerInstance)
-	deployment.Spec.Template.Spec.Volumes = append(deployment.Spec.Template.Spec.Volumes, volumeInstance)
-
-	return deployment
-
-}
-
 func CreateDeploymentWithAffinity(metadataName, selectorAppName, selectorClusterName string, numberOfReplicas int,
 	templateAppLabel, templateClusterLabel, namespace string, containerPort int, containerName, containerImage,
 	mountPath string, volumeName, configMapName string, readinessProbe int, requestCPU, requestMemory, limitCPU,
-	limitMemory, nodeAffinity string) (deploymentInstance model.DeploymentInstanceWithAffinity) {
+	limitMemory, nodeAffinity string) (deploymentInstance model.DeploymentInstance) {
 
-	var deployment model.DeploymentInstanceWithAffinity
+	var deployment model.DeploymentInstance
 	var containerInstance model.ContainerInstance
 	var containerPortInstance model.ContainerPortInstance
 	var containerVolume model.ContainerVolumeInstance


### PR DESCRIPTION
This PR closes #26 

Previously we had two deployment models, one with affinity and one without affinity. Now we have one deployment model, and if the user does not enter the nodename in service description, we won't add an empty string in the generated files. 

Example:
If the input json file is like this:
```
.
.
"services": [
    {
      "name": "service-1",
      "clusters": [
        {
          "cluster": "cluster-1",
          "namespace": "ns-1",
        }
      ],
      "resources": {
.
.
.
```

Before this PR the output would be like:
```
spec:
            nodeName: 
            containers:
                - name: app
                  image: app-demo:latest
                  imagePullPolicy: Never
```

After this PR the output is:
```
spec:
            containers:
                - name: app
                  image: app-demo:latest
                  imagePullPolicy: Never
```