### PR TITLE
Random service description file generation

### DIFF
--- a/generator/input/new_description.json
+++ b/generator/input/new_description.json
@@ -27,6 +27,7 @@
         }
       },
       "processes": 2,
+      "threads": 2,
       "readiness_probe": 5,
       "endpoints": [
         {

--- a/generator/input/new_description.json
+++ b/generator/input/new_description.json
@@ -27,6 +27,7 @@
         }
       },
       "processes": 2,
+      "readiness_probe": 5,
       "endpoints": [
         {
           "name": "/end-1",

--- a/generator/src/cmd/generate.go
+++ b/generator/src/cmd/generate.go
@@ -85,18 +85,18 @@ var generateCmd = &cobra.Command{
 
 			// NOTE: Here we assume numerically consecutive names for clusters and namespaces
 			clusterNamePrefix := stringPrompt("What is your cluster name prefix?")
-			clusterNumber := strconv.Atoi(stringPrompt("How many clusters do you have?"))
+			clusterNumber, _ := strconv.Atoi(stringPrompt("How many clusters do you have?"))
 			nsNamePrefix := stringPrompt("What is your namespace prefix?")
-			nsNumber := strconv.Atoi(stringPrompt("How many namespaces do you have?"))
+			nsNumber, _ := strconv.Atoi(stringPrompt("How many namespaces do you have?"))
 
 			svcMaxNumber := SvcMaxNumberDefault
 			svcReplicaMaxNumber := SvcReplicaMaxNumberDefault
 			svcEpMaxNumber := SvcEpMaxNumberDefault
 
 			if !simpleMode {
-				svcMaxNumber = strconv.Atoi(stringPrompt("Up to how many services do you want to have? (influences fan-out)"))
-				svcReplicaMaxNumber = strconv.Atoi(stringPrompt("Up to how many service replicas do you want to have?"))
-				svcEpMaxNumber = strconv.Atoi(stringPrompt("Up to how many service endpoints do you want to have? (fan-in)"))
+				svcMaxNumber, _ = strconv.Atoi(stringPrompt("Up to how many services do you want to have? (influences fan-out)"))
+				svcReplicaMaxNumber, _ = strconv.Atoi(stringPrompt("Up to how many service replicas do you want to have?"))
+				svcEpMaxNumber, _ = strconv.Atoi(stringPrompt("Up to how many service endpoints do you want to have? (fan-in)"))
 			}
 
 			var clusters, namespaces []string

--- a/generator/src/cmd/generate.go
+++ b/generator/src/cmd/generate.go
@@ -18,12 +18,8 @@ package cmd
 import (
 	"application-generator/src/pkg/generate"
 	"github.com/spf13/cobra"
+	"application-generator/src/pkg/model"
 )
-
-type ClusterConfig struct {
-  Clusters		[]string
-  Namespaces	[]string
-}
 
 var generateCmd = &cobra.Command{
 	Use:   "generate [mode] [input-file]",
@@ -36,7 +32,7 @@ var generateCmd = &cobra.Command{
 		var inputFile string
 		if mode == "random" {
 			// TODO: Change this hard-coded cluster configuration for actual user inputs
-			clusterConfig := ClusterConfig{
+			clusterConfig := model.ClusterConfig{
 				Clusters: 	[]string{"cluster1", "cluster2", "cluster3", "cluster4", "cluster5"},
 				Namespaces: []string{"namespace1", "namespace2", "namespace3"},
 			}

--- a/generator/src/cmd/generate.go
+++ b/generator/src/cmd/generate.go
@@ -38,8 +38,8 @@ var generateCmd = &cobra.Command{
 
 			// TODO: Change this hard-coded cluster configuration for actual user inputs
 			clusterConfig := ClusterConfig{
-				Clusters: 	["cluster1", "cluster2", "cluster3", "cluster4", "cluster5"],
-				Namespaces: ["namespace1", "namespace2", "namespace3"],
+				Clusters: 	[]string(["cluster1", "cluster2", "cluster3", "cluster4", "cluster5"]),
+				Namespaces: []string(["namespace1", "namespace2", "namespace3"]),
 			}
 
 			inputFile := CreateJsonInput(clusterConfig)

--- a/generator/src/cmd/generate.go
+++ b/generator/src/cmd/generate.go
@@ -19,7 +19,50 @@ import (
 	"application-generator/src/pkg/generate"
 	"github.com/spf13/cobra"
 	"application-generator/src/pkg/model"
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
 )
+
+func yesNoPrompt(label string, def bool) bool {
+  choices := "Y/n"
+  if !def {
+      choices = "y/N"
+  }
+
+  r := bufio.NewReader(os.Stdin)
+  var s string
+
+  for {
+      fmt.Fprintf(os.Stderr, "%s (%s) ", label, choices)
+      s, _ = r.ReadString('\n')
+      s = strings.TrimSpace(s)
+      if s == "" {
+          return def
+      }
+      s = strings.ToLower(s)
+      if s == "y" || s == "yes" {
+          return true
+      }
+      if s == "n" || s == "no" {
+          return false
+      }
+  }
+}
+
+func stringPrompt(label string) string {
+  var s string
+  r := bufio.NewReader(os.Stdin)
+  for {
+      fmt.Fprint(os.Stderr, label+" ")
+      s, _ = r.ReadString('\n')
+      if s != "" {
+          break
+      }
+  }
+  return strings.TrimSpace(s)
+}
 
 var generateCmd = &cobra.Command{
 	Use:   "generate [mode] [input-file]",
@@ -32,6 +75,21 @@ var generateCmd = &cobra.Command{
 		var inputFile string
 		if mode == "random" {
 			// TODO: Change this hard-coded cluster configuration for actual user inputs
+
+			simpleMode := yesNoPrompt("Do you want to set simple configuration? (otherwise, extended)", true)
+
+			clusterNamePrefix := stringPrompt("What is your cluster name prefix?")
+			clusterNumber := stringPrompt("How many clusters do you have?")
+			nsNamePrefix := stringPrompt("What is your namespace prefix?")
+			nsNumber := stringPrompt("How many namespaces do you have?")
+
+			if !simpleMode {
+				svcMaxNumber := stringPrompt("Up to how many services do you want to have?")
+				svcReplicaMaxNumber := stringPrompt("Up to how many service replicas do you want to have?")
+				svcInMaxNumber := stringPrompt("Up to how many service endpoints do you want to have? (fan-in)")
+				svcOutMaxNumber := stringPrompt("Up to how many service calls do you want to have? (fan-out)")
+			}
+
 			clusterConfig := model.ClusterConfig{
 				Clusters: 	[]string{"cluster-1", "cluster-2", "cluster-3", "cluster-4", "cluster-5"},
 				Namespaces: []string{"ns-1", "ns-2", "ns-3"},

--- a/generator/src/cmd/generate.go
+++ b/generator/src/cmd/generate.go
@@ -33,8 +33,8 @@ var generateCmd = &cobra.Command{
 		if mode == "random" {
 			// TODO: Change this hard-coded cluster configuration for actual user inputs
 			clusterConfig := model.ClusterConfig{
-				Clusters: 	[]string{"cluster1", "cluster2", "cluster3", "cluster4", "cluster5"},
-				Namespaces: []string{"namespace1", "namespace2", "namespace3"},
+				Clusters: 	[]string{"cluster-1", "cluster-2", "cluster-3", "cluster-4", "cluster-5"},
+				Namespaces: []string{"ns-1", "ns-2", "ns-3"},
 			}
 
 			inputFile = generate.CreateJsonInput(clusterConfig)

--- a/generator/src/cmd/generate.go
+++ b/generator/src/cmd/generate.go
@@ -21,17 +21,34 @@ import (
 	"strconv"
 )
 
-var generateCmd = &cobra.Command{
-	Use:   "generate [chain-file] [cluster-file] [k8s-readiness-probe]",
-	Short: "This commands generates Kubernetes manifest files by using example files in chains and clusters directory and also uses k8s readiness probe time",
-	Args:  cobra.ExactArgs(2),
-	Run: func(cmd *cobra.Command, args []string) {
-		chain := args[0]
-		readinessProbe, err := strconv.Atoi(args[1])
-		exitIfError(err)
+type ClusterConfig struct {
+  Clusters		[]string
+  Namespaces	[]string
+}
 
-		config, clusters := generate.Parse(chain)
-		generate.Create(config, readinessProbe, clusters)
+var generateCmd = &cobra.Command{
+	Use:   "generate [mode] [input-file]",
+	Short: "This commands can be run under two different modes: (i) 'random' mode which generates a random description file or (ii) 'preset' mode which generates Kubernetes manifest based on a description file in the input directory",
+	Args:  cobra.RangeArgs(1, 2),
+	Run: func(cmd *cobra.Command, args []string) {
+
+		mode := args[0]
+
+		if mode == "random" {
+
+			// TODO: Change this hard-coded cluster configuration for actual user inputs
+			clusterConfig := ClusterConfig{
+				Clusters: 	["cluster1", "cluster2", "cluster3", "cluster4", "cluster5"],
+				Namespaces: ["namespace1", "namespace2", "namespace3"],
+			}
+
+			inputFile := CreateJsonInput(clusterConfig)
+		} else if mode == "preset" {
+			inputFile := args[1]
+		}
+
+		config, clusters := generate.Parse(inputFile)
+		generate.CreateK8sYaml(config, clusters)
 	},
 }
 

--- a/generator/src/cmd/generate.go
+++ b/generator/src/cmd/generate.go
@@ -18,7 +18,6 @@ package cmd
 import (
 	"application-generator/src/pkg/generate"
 	"github.com/spf13/cobra"
-	"strconv"
 )
 
 type ClusterConfig struct {
@@ -34,17 +33,17 @@ var generateCmd = &cobra.Command{
 
 		mode := args[0]
 
+		var inputFile string
 		if mode == "random" {
-
 			// TODO: Change this hard-coded cluster configuration for actual user inputs
 			clusterConfig := ClusterConfig{
-				Clusters: 	[]string(["cluster1", "cluster2", "cluster3", "cluster4", "cluster5"]),
-				Namespaces: []string(["namespace1", "namespace2", "namespace3"]),
+				Clusters: 	[]string{"cluster1", "cluster2", "cluster3", "cluster4", "cluster5"},
+				Namespaces: []string{"namespace1", "namespace2", "namespace3"},
 			}
 
-			inputFile := CreateJsonInput(clusterConfig)
+			inputFile = generate.CreateJsonInput(clusterConfig)
 		} else if mode == "preset" {
-			inputFile := args[1]
+			inputFile = args[1]
 		}
 
 		config, clusters := generate.Parse(inputFile)

--- a/generator/src/cmd/generate.go
+++ b/generator/src/cmd/generate.go
@@ -89,7 +89,7 @@ var generateCmd = &cobra.Command{
 			nsNamePrefix := stringPrompt("What is your namespace prefix?")
 			nsNumber := strconv.Atoi(stringPrompt("How many namespaces do you have?"))
 
-			svcMaxNumber := svcMaxNumberDefault
+			svcMaxNumber := SvcMaxNumberDefault
 			svcReplicaMaxNumber := SvcReplicaMaxNumberDefault
 			svcEpMaxNumber := SvcEpMaxNumberDefault
 

--- a/generator/src/cmd/root.go
+++ b/generator/src/cmd/root.go
@@ -24,7 +24,7 @@ import (
 
 var rootCmd = &cobra.Command{
 	Use:  "application-generator",
-	Long: "Generates Kubernetes and Istio manifest files for given topoology",
+	Long: "Generates Kubernetes and Istio manifest files for given topology",
 }
 
 func Execute() {

--- a/generator/src/pkg/generate/generate.go
+++ b/generator/src/pkg/generate/generate.go
@@ -142,12 +142,12 @@ func CreateK8sYaml(config model.FileConfig, clusters []string) {
 		}
 
 		readinessProbe := config.Services[i].ReadinessProbe
-		if readinessProbe == nil {
+		if readinessProbe == 0 {
 			readinessProbe = serviceReadinessProbeDefault
 		}
 
 		processes := config.Services[i].Processes
-		if processes == nil {
+		if processes == 0 {
 			processes = serviceProcessesDefault
 		}
 
@@ -229,15 +229,15 @@ func CreateJsonInput(clusterConfig model.ClusterConfig) (string) {
 			var cluster model.Cluster
 
 			rIndex := rand.Intn(len(clusterConfig.Clusters))
-			cluster.cluster = clusterConfig.ClusterConfiglusters[rIndex]
+			cluster.Cluster = clusterConfig.Clusters[rIndex]
 
 			rIndex = rand.Intn(len(clusterConfig.Namespaces))
-			cluster.namespace = clusterConfig.Namespaces[rIndex]
+			cluster.Namespace = clusterConfig.Namespaces[rIndex]
 
 			service.Clusters = append(service.Clusters, cluster)
 		}
 
-		var resources Resources
+		var resources model.Resources
 		resources.ResourceLimits.Cpu = limitsCPUDefault
 		resources.ResourceLimits.Memory = limitsMemoryDefault
 		resources.ResourceRequests.Cpu = requestsCPUDefault
@@ -258,7 +258,6 @@ func CreateJsonInput(clusterConfig model.ClusterConfig) (string) {
 	err = ioutil.WriteFile(path, input_json, 0644)
 	if err != nil {
 		fmt.Print(err)
-		return
 	}
 
 	return path

--- a/generator/src/pkg/generate/generate.go
+++ b/generator/src/pkg/generate/generate.go
@@ -292,7 +292,7 @@ func CreateJsonInput(clusterConfig model.ClusterConfig) (string) {
 					var calledService model.CalledService
 
 					calledService.Service = svcNamePrefix + strconv.Itoa(n)
-					calledService.Port = strconv.Atoi(defaultExtPort)
+					calledService.Port, _ = strconv.Atoi(defaultExtPort)
 					// NOTE: Always calling the first endpoint of the called service
 					calledService.Endpoint = epNamePrefix + "1"
 					calledService.Protocol = protocol

--- a/generator/src/pkg/generate/generate.go
+++ b/generator/src/pkg/generate/generate.go
@@ -249,11 +249,11 @@ func CreateJsonInput(clusterConfig model.ClusterConfig) (string) {
 		for j := 1; j <= replicaNumber; j++ {
 			var cluster model.Cluster
 
-			rIndex := rand.Intn(len(clusterConfig.Clusters))
-			cluster.Cluster = clusterConfig.Clusters[rIndex]
+			cRIndex := rand.Intn(len(clusterConfig.Clusters))
+			cluster.Cluster = clusterConfig.Clusters[cRIndex]
 
-			rIndex = rand.Intn(len(clusterConfig.Namespaces))
-			cluster.Namespace = clusterConfig.Namespaces[rIndex]
+			nRIndex := rand.Intn(len(clusterConfig.Namespaces))
+			cluster.Namespace = clusterConfig.Namespaces[nRIndex]
 
 			service.Clusters = append(service.Clusters, cluster)
 		}
@@ -266,6 +266,7 @@ func CreateJsonInput(clusterConfig model.ClusterConfig) (string) {
 		service.Resources = resources
 
 		service.Processes = svcProcessesDefault
+		service.Threads = svcThreadsDefault
 		service.ReadinessProbe = svcReadinessProbeDefault
 
 		// Randomly generating service endpoints

--- a/generator/src/pkg/generate/generate.go
+++ b/generator/src/pkg/generate/generate.go
@@ -291,7 +291,7 @@ func CreateJsonInput(clusterConfig model.ClusterConfig) (string) {
 				for n := i + 1; n <= calledServiceNumber; n++ {
 					var calledService model.CalledService
 
-					calledService.Service = svcNamePrefix + n
+					calledService.Service = svcNamePrefix + strconv.Itoa(n)
 					calledService.Port = defaultExtPort
 					// NOTE: Always calling the first endpoint of the called service
 					calledService.Endpoint = epNamePrefix + "1"

--- a/generator/src/pkg/generate/generate.go
+++ b/generator/src/pkg/generate/generate.go
@@ -63,7 +63,7 @@ var (
 
 type ConfigMap struct {
 	Processes	int					`json:"processes"`
-	Endpoints []Endpoints	`json:"endpoints"`
+	Endpoints []Endpoint	`json:"endpoints"`
 }
 
 // the slices to store services, cluster and endpoints for counting and printing
@@ -83,7 +83,7 @@ func Unique(strSlice []string) []string {
 }
 
 // Parse microservice config file, and return a config struct
-func Parse(configFilename string) (FileConfig, []string) {
+func Parse(configFilename string) (model.FileConfig, []string) {
 	configFile, err := os.Open(configFilename)
 	configFileByteValue, _ := ioutil.ReadAll(configFile)
 
@@ -91,7 +91,7 @@ func Parse(configFilename string) (FileConfig, []string) {
 		fmt.Println(err)
 	}
 
-	var loaded_config FileConfig
+	var loaded_config model.FileConfig
 	json.Unmarshal(configFileByteValue, &loaded_config)
 	for i := 0; i < len(loaded_config.Services); i++ {
 		services = append(services, loaded_config.Services[i].Name)
@@ -115,7 +115,7 @@ func Parse(configFilename string) (FileConfig, []string) {
 	return loaded_config, clusters
 }
 
-func CreateK8sYaml(config FileConfig, clusters []string) {
+func CreateK8sYaml(config model.FileConfig, clusters []string) {
 	path, _ := os.Getwd()
 	path = path + "/k8s"
 
@@ -126,7 +126,7 @@ func CreateK8sYaml(config FileConfig, clusters []string) {
 
 	for i := 0; i < len(config.Services); i++ {
 		serv := config.Services[i].Name
-		resources := Resources(config.Services[i].Resources)
+		resources := model.Resources(config.Services[i].Resources)
 
 		if resources.Limits.Cpu == "" {
 			resources.Limits.Cpu = limitsCPUDefault
@@ -142,18 +142,18 @@ func CreateK8sYaml(config FileConfig, clusters []string) {
 		}
 
 		readinessProbe := config.Services[i].ReadinessProbe
-		if readinessProbe == NULL {
+		if readinessProbe == nil {
 			readinessProbe = serviceReadinessProbeDefault
 		}
 
 		processes := config.Services[i].Processes
-		if processes == NULL {
+		if processes == nil {
 			processes = serviceProcessesDefault
 		}
 
 		cm_data := &ConfigMap{
 			Processes: processes,
-			Endpoints: []Endpoints(config.Services[i].Endpoints),
+			Endpoints: []Endpoint(config.Services[i].Endpoints),
 		}
 
 		serv_json, err := json.Marshal(cm_data)
@@ -206,7 +206,7 @@ func CreateK8sYaml(config FileConfig, clusters []string) {
 	}
 }
 
-func CreateJsonInput(clusterConfig ClusterConfig) (string) {
+func CreateJsonInput(clusterConfig model.ClusterConfig) (string) {
 	path, _ := os.Getwd()
 	path = path + "/input/new_description_test.json"
 
@@ -255,7 +255,7 @@ func CreateJsonInput(clusterConfig ClusterConfig) (string) {
 		panic(err)
 	}
 
-	err := ioutil.WriteFile(path, input_json, 0644)
+	err = ioutil.WriteFile(path, input_json, 0644)
 	if err != nil {
 		fmt.Print(err)
 		return

--- a/generator/src/pkg/generate/generate.go
+++ b/generator/src/pkg/generate/generate.go
@@ -24,6 +24,7 @@ import (
 	"io/ioutil"
 	"os"
 	"strings"
+	"math/rand"
 )
 
 const (
@@ -46,6 +47,9 @@ const (
 	requestsMemoryDefault = "256M"
 	limitsCPUDefault      = "1000m"
 	limitsMemoryDefault   = "1024M"
+
+	serviceProcessesDefault = 2
+	serviceReadinessProbeDefault = 5
 )
 
 var (
@@ -56,59 +60,6 @@ var (
 	virtualService   model.VirtualServiceInstance
 	workerDeployment model.DeploymentInstance
 )
-
-type CalledServices struct {
-	Service             string  `json:"service"`
-	Port           			string	`json:"port"`
-	Endpoint            string  `json:"endpoint"`
-	Protocol            string  `json:"protocol"`
-	TrafficForwardRatio float32 `json:"traffic_forward_ratio"`
-}
-type Endpoints struct {
-	Name               string           `json:"name"`
-	Protocol           string						`json:"protocol"`
-	CpuConsumption     float64          `json:"cpu_consumption"`
-	NetworkConsumption float64          `json:"network_consumption"`
-	MemoryConsumption  float64          `json:"memory_consumption"`
-	ForwardRequests    string  					`json:"forward_requests"`
-	CalledServices     []CalledServices `json:"called_services"`
-}
-type ResourceLimits struct {
-	Cpu    string `json:"cpu"`
-	Memory string `json:"memory"`
-}
-type ResourceRequests struct {
-	Cpu    string `json:"cpu"`
-	Memory string `json:"memory"`
-}
-type Resources struct {
-	Limits   ResourceLimits   `json:"limits"`
-	Requests ResourceRequests `json:"requests"`
-}
-type Services struct {
-	Name      string      `json:"name"`
-	Clusters  []Clusters  `json:"clusters"`
-	Resources Resources   `json:"resources"`
-	Processes	int					`json:"processes"`
-	Endpoints []Endpoints `json:"endpoints"`
-}
-
-type Clusters struct {
-	Cluster   string `json:"cluster"`
-	Namespace string `json:"namespace"`
-	Node      string `json:"node"`
-}
-
-type Latencies struct {
-	Src     string  `json:"src"`
-	Dest    string  `json:"dest"`
-	Latancy float64 `json:"latency"`
-}
-
-type Config struct {
-	Latencies []Latencies `json:"cluster_latencies"`
-	Services  []Services  `json:"services"`
-}
 
 type ConfigMap struct {
 	Processes	int					`json:"processes"`
@@ -132,7 +83,7 @@ func Unique(strSlice []string) []string {
 }
 
 // Parse microservice config file, and return a config struct
-func Parse(configFilename string) (Config, []string) {
+func Parse(configFilename string) (FileConfig, []string) {
 	configFile, err := os.Open(configFilename)
 	configFileByteValue, _ := ioutil.ReadAll(configFile)
 
@@ -140,7 +91,7 @@ func Parse(configFilename string) (Config, []string) {
 		fmt.Println(err)
 	}
 
-	var loaded_config Config
+	var loaded_config FileConfig
 	json.Unmarshal(configFileByteValue, &loaded_config)
 	for i := 0; i < len(loaded_config.Services); i++ {
 		services = append(services, loaded_config.Services[i].Name)
@@ -164,7 +115,7 @@ func Parse(configFilename string) (Config, []string) {
 	return loaded_config, clusters
 }
 
-func Create(config Config, readinessProbe int, clusters []string) {
+func CreateK8sYaml(config FileConfig, clusters []string) {
 	path, _ := os.Getwd()
 	path = path + "/k8s"
 
@@ -190,8 +141,18 @@ func Create(config Config, readinessProbe int, clusters []string) {
 			resources.Requests.Memory = requestsMemoryDefault
 		}
 
+		readinessProbe := config.Services[i].ReadinessProbe
+		if readinessProbe == NULL {
+			readinessProbe = serviceReadinessProbeDefault
+		}
+
+		processes := config.Services[i].Processes
+		if processes == NULL {
+			processes = serviceProcessesDefault
+		}
+
 		cm_data := &ConfigMap{
-			Processes: int(config.Services[i].Processes),
+			Processes: processes,
 			Endpoints: []Endpoints(config.Services[i].Endpoints),
 		}
 
@@ -243,4 +204,60 @@ func Create(config Config, readinessProbe int, clusters []string) {
 
 		}
 	}
+}
+
+func CreateJsonInput(clusterConfig ClusterConfig) (string) {
+	path, _ := os.Getwd()
+	path = path + "/input/new_description_test.json"
+
+	var inputConfig FileConfig
+
+	// TODO: Generate cluster latencies
+
+	// Generating random services
+	serviceNumber := rand.Intn(10)
+	for i := 1; i <= serviceNumber; i++ {
+		var service Service
+
+		service.name = "service" + i
+
+		// Randomly associating services to clusters
+		replicaNumber := rand.Intn(5)
+		for j := 1; j <= replicaNumber; j++ {
+			var cluster Cluster
+
+			rIndex := rand.Intn(len(clusterConfig.clusters))
+			cluster.cluster = clusterConfig.clusters[rIndex]
+
+			rIndex = rand.Intn(len(clusterConfig.namespaces))
+			cluster.namespace = clusterConfig.namespaces[rIndex]
+
+			service.clusters = append(service.clusters, cluster)
+		}
+
+		var resource Resource
+		resource.limits.cpu = limitsCPUDefault
+		resource.limits.memory = limitsMemoryDefault
+		resource.requests.cpu = requestsCPUDefault
+		resource.requests.memory = requestsMemoryDefault
+		service.resource = resource
+
+		service.processes = serviceProcessesDefault
+		service.readinessProbe = serviceReadinessProbeDefault
+
+		inputConfig.services = append(inputConfig.services, service)
+	}
+
+	input_json, err := json.MarshalIndent(inputConfig, "", " ")
+	if err != nil {
+		panic(err)
+	}
+
+	err := ioutil.WriteFile(path, input_json, 0644)
+	if err != nil {
+		fmt.Print(err)
+		return
+	}
+
+	return path
 }

--- a/generator/src/pkg/generate/generate.go
+++ b/generator/src/pkg/generate/generate.go
@@ -292,7 +292,7 @@ func CreateJsonInput(clusterConfig model.ClusterConfig) (string) {
 					var calledService model.CalledService
 
 					calledService.Service = svcNamePrefix + strconv.Itoa(n)
-					calledService.Port, _ = strconv.Atoi(defaultExtPort)
+					calledService.Port = strconv.Itoa(defaultExtPort)
 					// NOTE: Always calling the first endpoint of the called service
 					calledService.Endpoint = epNamePrefix + "1"
 					calledService.Protocol = protocol

--- a/generator/src/pkg/generate/generate.go
+++ b/generator/src/pkg/generate/generate.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"strings"
 	"math/rand"
+	"strconv"
 )
 
 const (
@@ -238,10 +239,10 @@ func CreateJsonInput(clusterConfig model.ClusterConfig) (string) {
 		}
 
 		var resources model.Resources
-		resources.ResourceLimits.Cpu = limitsCPUDefault
-		resources.ResourceLimits.Memory = limitsMemoryDefault
-		resources.ResourceRequests.Cpu = requestsCPUDefault
-		resources.ResourceRequests.memory = requestsMemoryDefault
+		resources.Limits.Cpu = limitsCPUDefault
+		resources.Limits.Memory = limitsMemoryDefault
+		resources.Requests.Cpu = requestsCPUDefault
+		resources.Requests.memory = requestsMemoryDefault
 		service.Resources = resources
 
 		service.Processes = serviceProcessesDefault

--- a/generator/src/pkg/generate/generate.go
+++ b/generator/src/pkg/generate/generate.go
@@ -242,7 +242,7 @@ func CreateJsonInput(clusterConfig model.ClusterConfig) (string) {
 		resources.Limits.Cpu = limitsCPUDefault
 		resources.Limits.Memory = limitsMemoryDefault
 		resources.Requests.Cpu = requestsCPUDefault
-		resources.Requests.memory = requestsMemoryDefault
+		resources.Requests.Memory = requestsMemoryDefault
 		service.Resources = resources
 
 		service.Processes = serviceProcessesDefault

--- a/generator/src/pkg/generate/generate.go
+++ b/generator/src/pkg/generate/generate.go
@@ -225,7 +225,7 @@ func CreateK8sYaml(config model.FileConfig, clusters []string) {
 	}
 }
 
-func CreateJsonInput(clusterConfig model.ClusterConfig) (string) {
+func CreateJsonInput(userConfig model.UserConfig) (string) {
 	path, _ := os.Getwd()
 	path = path + "/input/new_description_test.json"
 
@@ -236,24 +236,22 @@ func CreateJsonInput(clusterConfig model.ClusterConfig) (string) {
 	// TODO: Generate cluster latencies
 
 	// Generating random services
-	// TODO: Replace this hard-coded number of services with the ones given by the user
-	serviceNumber := rand.Intn(10) + 1
+	serviceNumber := rand.Intn(userConfig.svcMaxNumber) + 1
 	for i := 1; i <= serviceNumber; i++ {
 		var service model.Service
 
 		service.Name = svcNamePrefix + strconv.Itoa(i)
 
 		// Randomly associating services to clusters
-		// TODO: Replace this hard-coded number of service replicas with the ones given by the user
-		replicaNumber := rand.Intn(5) + 1
+		replicaNumber := rand.Intn(userConfig.SvcReplicaMaxNumber) + 1
 		for j := 1; j <= replicaNumber; j++ {
 			var cluster model.Cluster
 
-			cRIndex := rand.Intn(len(clusterConfig.Clusters))
-			cluster.Cluster = clusterConfig.Clusters[cRIndex]
+			cRIndex := rand.Intn(len(userConfig.Clusters))
+			cluster.Cluster = userConfig.Clusters[cRIndex]
 
-			nRIndex := rand.Intn(len(clusterConfig.Namespaces))
-			cluster.Namespace = clusterConfig.Namespaces[nRIndex]
+			nRIndex := rand.Intn(len(userConfig.Namespaces))
+			cluster.Namespace = userConfig.Namespaces[nRIndex]
 
 			service.Clusters = append(service.Clusters, cluster)
 		}
@@ -270,8 +268,7 @@ func CreateJsonInput(clusterConfig model.ClusterConfig) (string) {
 		service.ReadinessProbe = svcReadinessProbeDefault
 
 		// Randomly generating service endpoints
-		// TODO: Replace this hard-coded number of service endpoints with the ones given by the user
-		endpointNumber := rand.Intn(5) + 1
+		endpointNumber := rand.Intn(userConfig.SvcEpMaxNumber) + 1
 		for k := 1; k <= endpointNumber; k++ {
 			var endpoint model.Endpoint
 
@@ -283,8 +280,6 @@ func CreateJsonInput(clusterConfig model.ClusterConfig) (string) {
 			endpoint.ForwardRequests = epForwardRequests
 
 			// Randomly generating called services
-			// TODO: Replace this hard-coded number of called services with the ones given by the user
-
 			// NOTE: Last service does not call any service to ensure the sequence of calls ends
 			if i < serviceNumber {
 				// NOTE: Services only call subsequent services to avoid endless loops

--- a/generator/src/pkg/generate/generate.go
+++ b/generator/src/pkg/generate/generate.go
@@ -236,7 +236,7 @@ func CreateJsonInput(userConfig model.UserConfig) (string) {
 	// TODO: Generate cluster latencies
 
 	// Generating random services
-	serviceNumber := rand.Intn(userConfig.svcMaxNumber) + 1
+	serviceNumber := rand.Intn(userConfig.SvcMaxNumber) + 1
 	for i := 1; i <= serviceNumber; i++ {
 		var service model.Service
 

--- a/generator/src/pkg/generate/generate.go
+++ b/generator/src/pkg/generate/generate.go
@@ -292,7 +292,7 @@ func CreateJsonInput(clusterConfig model.ClusterConfig) (string) {
 					var calledService model.CalledService
 
 					calledService.Service = svcNamePrefix + strconv.Itoa(n)
-					calledService.Port = defaultExtPort
+					calledService.Port = strconv.Atoi(defaultExtPort)
 					// NOTE: Always calling the first endpoint of the called service
 					calledService.Endpoint = epNamePrefix + "1"
 					calledService.Protocol = protocol

--- a/generator/src/pkg/generate/generate.go
+++ b/generator/src/pkg/generate/generate.go
@@ -63,7 +63,7 @@ var (
 
 type ConfigMap struct {
 	Processes	int					`json:"processes"`
-	Endpoints []Endpoint	`json:"endpoints"`
+	Endpoints []model.Endpoint	`json:"endpoints"`
 }
 
 // the slices to store services, cluster and endpoints for counting and printing
@@ -153,7 +153,7 @@ func CreateK8sYaml(config model.FileConfig, clusters []string) {
 
 		cm_data := &ConfigMap{
 			Processes: processes,
-			Endpoints: []Endpoint(config.Services[i].Endpoints),
+			Endpoints: []model.Endpoint(config.Services[i].Endpoints),
 		}
 
 		serv_json, err := json.Marshal(cm_data)
@@ -210,7 +210,7 @@ func CreateJsonInput(clusterConfig model.ClusterConfig) (string) {
 	path, _ := os.Getwd()
 	path = path + "/input/new_description_test.json"
 
-	var inputConfig FileConfig
+	var inputConfig model.FileConfig
 
 	// TODO: Generate cluster latencies
 
@@ -218,21 +218,21 @@ func CreateJsonInput(clusterConfig model.ClusterConfig) (string) {
 	// TODO: Replace this hard-coded number of services by the ones given by the user
 	serviceNumber := rand.Intn(10)
 	for i := 1; i <= serviceNumber; i++ {
-		var service Service
+		var service model.Service
 
-		service.Name = "service" + i
+		service.Name = "service" + strconv.Itoa(i)
 
 		// Randomly associating services to clusters
 		// TODO: Replace this hard-coded number of service replicas by the ones given by the user
 		replicaNumber := rand.Intn(5)
 		for j := 1; j <= replicaNumber; j++ {
-			var cluster Cluster
+			var cluster model.Cluster
 
-			rIndex := rand.Intn(len(clusterConfig.clusters))
-			cluster.cluster = clusterConfig.clusters[rIndex]
+			rIndex := rand.Intn(len(clusterConfig.Clusters))
+			cluster.cluster = clusterConfig.ClusterConfiglusters[rIndex]
 
-			rIndex = rand.Intn(len(clusterConfig.namespaces))
-			cluster.namespace = clusterConfig.namespaces[rIndex]
+			rIndex = rand.Intn(len(clusterConfig.Namespaces))
+			cluster.namespace = clusterConfig.Namespaces[rIndex]
 
 			service.Clusters = append(service.Clusters, cluster)
 		}

--- a/generator/src/pkg/generate/generate.go
+++ b/generator/src/pkg/generate/generate.go
@@ -75,7 +75,7 @@ var (
 
 type ConfigMap struct {
 	Processes	int								`json:"processes"`
-	Threads		int()							`json:"threads"`
+	Threads		int								`json:"threads"`
 	Endpoints []model.Endpoint	`json:"endpoints"`
 }
 

--- a/generator/src/pkg/generate/generate.go
+++ b/generator/src/pkg/generate/generate.go
@@ -215,13 +215,15 @@ func CreateJsonInput(clusterConfig ClusterConfig) (string) {
 	// TODO: Generate cluster latencies
 
 	// Generating random services
+	// TODO: Replace this hard-coded number of services by the ones given by the user
 	serviceNumber := rand.Intn(10)
 	for i := 1; i <= serviceNumber; i++ {
 		var service Service
 
-		service.name = "service" + i
+		service.Name = "service" + i
 
 		// Randomly associating services to clusters
+		// TODO: Replace this hard-coded number of service replicas by the ones given by the user
 		replicaNumber := rand.Intn(5)
 		for j := 1; j <= replicaNumber; j++ {
 			var cluster Cluster
@@ -232,20 +234,20 @@ func CreateJsonInput(clusterConfig ClusterConfig) (string) {
 			rIndex = rand.Intn(len(clusterConfig.namespaces))
 			cluster.namespace = clusterConfig.namespaces[rIndex]
 
-			service.clusters = append(service.clusters, cluster)
+			service.Clusters = append(service.Clusters, cluster)
 		}
 
-		var resource Resource
-		resource.limits.cpu = limitsCPUDefault
-		resource.limits.memory = limitsMemoryDefault
-		resource.requests.cpu = requestsCPUDefault
-		resource.requests.memory = requestsMemoryDefault
-		service.resource = resource
+		var resources Resources
+		resources.ResourceLimits.Cpu = limitsCPUDefault
+		resources.ResourceLimits.Memory = limitsMemoryDefault
+		resources.ResourceRequests.Cpu = requestsCPUDefault
+		resources.ResourceRequests.memory = requestsMemoryDefault
+		service.Resources = resources
 
-		service.processes = serviceProcessesDefault
-		service.readinessProbe = serviceReadinessProbeDefault
+		service.Processes = serviceProcessesDefault
+		service.ReadinessProbe = serviceReadinessProbeDefault
 
-		inputConfig.services = append(inputConfig.services, service)
+		inputConfig.Services = append(inputConfig.Services, service)
 	}
 
 	input_json, err := json.MarshalIndent(inputConfig, "", " ")

--- a/generator/src/pkg/model/input.go
+++ b/generator/src/pkg/model/input.go
@@ -74,3 +74,8 @@ type FileConfig struct {
 	ClusterLatencies	[]ClusterLatency	`json:"cluster_latencies"`
 	Services  				[]Service	  			`json:"services"`
 }
+
+type ClusterConfig struct {
+  Clusters		[]string
+  Namespaces	[]string
+}

--- a/generator/src/pkg/model/input.go
+++ b/generator/src/pkg/model/input.go
@@ -54,6 +54,7 @@ type Service struct {
 	Clusters  			[]Cluster		`json:"clusters"`
 	Resources 			Resources   `json:"resources"`
 	Processes				int					`json:"processes"`
+	Threads					int					`json:"threads"`
 	ReadinessProbe	int					`json:"readiness_probe"`
 	Endpoints 			[]Endpoint	`json:"endpoints"`
 }

--- a/generator/src/pkg/model/input.go
+++ b/generator/src/pkg/model/input.go
@@ -72,5 +72,5 @@ type ClusterLatency struct {
 
 type FileConfig struct {
 	ClusterLatencies	[]ClusterLatency	`json:"cluster_latencies"`
-	Services  				[]Services  			`json:"services"`
+	Services  				[]Service	  			`json:"services"`
 }

--- a/generator/src/pkg/model/input.go
+++ b/generator/src/pkg/model/input.go
@@ -76,7 +76,14 @@ type FileConfig struct {
 	Services  				[]Service	  			`json:"services"`
 }
 
-type ClusterConfig struct {
-  Clusters		[]string
-  Namespaces	[]string
+type UserConfig struct {
+  Clusters						[]string
+  Namespaces					[]string
+	ClusterNamePrefix		string
+	ClusterNumber				int
+	NsNamePrefix				string
+	NsNumber						int
+	SvcMaxNumber				int
+	SvcReplicaMaxNumber int
+	SvcEpMaxNumber			int
 }

--- a/generator/src/pkg/model/input.go
+++ b/generator/src/pkg/model/input.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2021 Telefonaktiebolaget LM Ericsson AB
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package model
+
+type CalledService struct {
+	Service             string  `json:"service"`
+	Port           			string	`json:"port"`
+	Endpoint            string  `json:"endpoint"`
+	Protocol            string  `json:"protocol"`
+	TrafficForwardRatio float32 `json:"traffic_forward_ratio"`
+}
+
+type Endpoint struct {
+	Name               string           `json:"name"`
+	Protocol           string						`json:"protocol"`
+	CpuConsumption     float64          `json:"cpu_consumption"`
+	NetworkConsumption float64          `json:"network_consumption"`
+	MemoryConsumption  float64          `json:"memory_consumption"`
+	ForwardRequests    string  					`json:"forward_requests"`
+	CalledServices     []CalledService	`json:"called_services"`
+}
+
+type ResourceLimits struct {
+	Cpu    string `json:"cpu"`
+	Memory string `json:"memory"`
+}
+
+type ResourceRequests struct {
+	Cpu    string `json:"cpu"`
+	Memory string `json:"memory"`
+}
+
+type Resources struct {
+	Limits   ResourceLimits   `json:"limits"`
+	Requests ResourceRequests `json:"requests"`
+}
+
+type Service struct {
+	Name      			string      `json:"name"`
+	Clusters  			[]Cluster		`json:"clusters"`
+	Resources 			Resources   `json:"resources"`
+	Processes				int					`json:"processes"`
+	ReadinessProbe	int					`json:"readiness_probe"`
+	Endpoints 			[]Endpoint	`json:"endpoints"`
+}
+
+type Cluster struct {
+	Cluster   string `json:"cluster"`
+	Namespace string `json:"namespace"`
+	Node      string `json:"node"`
+}
+
+type ClusterLatency struct {
+	Src     string  `json:"src"`
+	Dest    string  `json:"dest"`
+	Latency float64 `json:"latency"`
+}
+
+type FileConfig struct {
+	ClusterLatencies	[]ClusterLatency	`json:"cluster_latencies"`
+	Services  				[]Services  			`json:"services"`
+}


### PR DESCRIPTION
closes #10

The user can now run the service description generator under two different modes: (i) 'random' mode which generates a random description file or (ii) 'preset' mode which generates Kubernetes manifest based on a description file in the input directory".

Then, via an interactive process the user can then choose between "simple" or "extended" configuration mode.

In both cases, the user will need to specify as minimum the following params: cluster prefix, number of clusters, namespace prefix, number of namespaces. In the extended case, the user will need to also specify: maximum number of services, maximum number of cross-cluster replicas per service and maximum number of endpoints per service.

After that, the code will generate both the json input file and the respective k8s yaml files.