### PR TITLE
Fix/unexpected output

### DIFF
--- a/model/restful/resources/endpoint.py
+++ b/model/restful/resources/endpoint.py
@@ -35,4 +35,16 @@ class Endpoint(Resource):
                     return res
         not_found(endpoint)
 
+    def post(self, endpoint=None):
+        if endpoint is None:
+            message = {"status": "ok"}
+            return message
+        else:
+            for ep in SERVICE_CONFIG['endpoints']:
+                if ep['name'] == endpoint:
+                    res = task.run_task(service_endpoint=ep)
+                    return res
+        not_found(endpoint)
+
+
 

--- a/model/restful/utils/task.py
+++ b/model/restful/utils/task.py
@@ -99,7 +99,7 @@ async def sync_tasks(service_endpoint, headers):
             json_data = request.json
         if len(service_endpoint["called_services"]) > 0:
             for svc in service_endpoint["called_services"]:
-                res = execute_io_bounded_task(session=session, target_service=svc, json_data=json_data, forward_headers=headers)
+                res = await execute_io_bounded_task(session=session, target_service=svc, json_data=json_data, forward_headers=headers)
                 response["services"] += res["services"]
                 response["statuses"] += res["statuses"]
 


### PR DESCRIPTION
As there was a problem with `asynchronous` and `synchronous`  forwarding requests, in this PR, we suggest:

- split them into separate coroutine functions and make `run_task` function a not a coroutine
- Add post method for the endpoints.

This PR is tested for the following architecture:
```mermaid
graph TD;
    A-->B;
```

The following are the outputs of testing on `kind`:
**The output for Asynchronous**
```
root@service1-75576df8cd-4jwqz:/usr/src/app# curl service1/end1
{"services": ["http://service2:80/end2"], "statuses": [200]}
root@service1-75576df8cd-4jwqz:/usr/src/app# curl service2/end2
{"services": [], "statuses": []}

```

**The output for Synchronous**
```
root@service1-75576df8cd-7kz5h:/usr/src/app# curl service1/end1
{"services": ["http://service2:80/end2"], "statuses": [200]}
root@service1-75576df8cd-7kz5h:/usr/src/app# curl service2/end2
{"services": [], "statuses": []}
```

