### PR TITLE
Stress-ng customisation of timeout

### DIFF
--- a/generator/src/pkg/service/util.go
+++ b/generator/src/pkg/service/util.go
@@ -50,7 +50,7 @@ const (
 	EpExecModeDefault       = "sequential"
 	EpNwResponseSizeDefault = 512
 
-	EpExecTimeDefault = "1s"
+	EpExecTimeDefault = "0.1s"
 	EpMethodDefault   = "all"
 	EpWorkersDefault  = 1
 	EpLoadDefault     = "5%"

--- a/model/Dockerfile
+++ b/model/Dockerfile
@@ -18,12 +18,35 @@ FROM python:3.8.0-slim
 
 RUN mkdir -p /usr/src/app
 RUN apt update
+RUN apt upgrade -y
 RUN apt install -y jq \
     wget \
-    stress-ng \
     2to3
 
+RUN apt install -y libbsd-dev \
+    libcap-dev \
+    libipsec-mb-dev \
+    libjudy-dev \
+    libkeyutils-dev \
+    libsctp-dev \
+    libatomic1 \
+    zlib1g-dev \
+    libkmod-dev \
+    libxxhash-dev \
+    git \
+    build-essential
+
 WORKDIR /usr/src/app
+
+RUN git clone https://github.com/alekodu/stress-ng.git &&\
+    cd stress-ng/ &&\
+    git checkout cloudsim &&\
+    make clean &&\
+    make &&\
+    mv stress-ng my-stress-ng &&\
+    cp my-stress-ng /usr/src/app &&\
+    cd .. &&\
+    rm -R stress-ng/
 
 ADD ./requirements.txt /usr/src/app/requirements.txt
 

--- a/model/restful/utils/task.py
+++ b/model/restful/utils/task.py
@@ -110,15 +110,15 @@ def run_task(service_name, service_endpoint):
 
 def execute_cpu_bounded_task(conf):
     if len(conf["cpu_affinity"]) > 0:
-        res = subprocess.run(['stress-ng --class cpu --cpu %s --cpu-method %s --taskset %s --cpu-load %s --timeout %s --metrics-brief' % (conf["workers"], conf["method"], ",".join(str(cpu_id) for cpu_id in conf["cpu_affinity"]), conf["cpu_load"], conf["execution_time"])], capture_output=True, shell=True)
+        res = subprocess.run(['/usr/src/app/my-stress-ng --class cpu --cpu %s --cpu-method %s --taskset %s --cpu-load %s --timeout %s --metrics-brief' % (conf["workers"], conf["method"], ",".join(str(cpu_id) for cpu_id in conf["cpu_affinity"]), conf["cpu_load"], conf["execution_time"])], capture_output=True, shell=True)
     else:
-        res = subprocess.run(['stress-ng --class cpu --cpu %s --cpu-method %s --cpu-load %s --timeout %s --metrics-brief' % (conf["workers"], conf["method"], conf["cpu_load"], conf["execution_time"])], capture_output=True, shell=True)
+        res = subprocess.run(['/usr/src/app/my-stress-ng --class cpu --cpu %s --cpu-method %s --cpu-load %s --timeout %s --metrics-brief' % (conf["workers"], conf["method"], conf["cpu_load"], conf["execution_time"])], capture_output=True, shell=True)
 
     return res.stderr.decode("utf-8"), "cpu"
 
 
 def execute_memory_bounded_task(conf):
-    res = subprocess.run(['stress-ng --class memory --vm %s --vm-method %s --vm-bytes %s --timeout %s --metrics-brief' % (conf["workers"], conf["method"], conf["bytes_load"], conf["execution_time"])], capture_output=True, shell=True)
+    res = subprocess.run(['/usr/src/app/my-stress-ng --class memory --vm %s --vm-method %s --vm-bytes %s --timeout %s --metrics-brief' % (conf["workers"], conf["method"], conf["bytes_load"], conf["execution_time"])], capture_output=True, shell=True)
 
     return res.stderr.decode("utf-8"), "memory"
 


### PR DESCRIPTION
closes #48

Customising stress-ng  to support timeout < 1s (up to the order of microseconds)