### PR TITLE
add replication

### DIFF
--- a/generator/input/new_description.json
+++ b/generator/input/new_description.json
@@ -15,6 +15,7 @@
       "clusters": [
         {
           "cluster": "cluster-1",
+          "replicas": 1,
           "namespace": "default",
           "node": "node-1"
         }

--- a/generator/src/pkg/generate/generate.go
+++ b/generator/src/pkg/generate/generate.go
@@ -141,6 +141,7 @@ func CreateK8sYaml(config model.FileConfig, clusters []string) {
 
 		for j := 0; j < len(config.Services[i].Clusters); j++ {
 			directory := config.Services[i].Clusters[j].Cluster
+			replicas := config.Services[i].Clusters[j].Replicas
 			directory_path := fmt.Sprintf(path+"/%s", directory)
 			c_id := config.Services[i].Clusters[j].Cluster
 			nodeAffinity := config.Services[i].Clusters[j].Node
@@ -158,7 +159,7 @@ func CreateK8sYaml(config model.FileConfig, clusters []string) {
 			configmap := s.CreateConfig("config-"+serv, "config-"+serv, c_id, namespace, string(serv_json), proto_temp_filled)
 			appendManifest(configmap)
 
-			deployment := s.CreateDeployment(serv, serv, c_id, s.ReplicaNumber, serv, c_id, namespace,
+			deployment := s.CreateDeployment(serv, serv, c_id, replicas, serv, c_id, namespace,
 				s.DefaultPort, s.ImageName, s.ImageURL, s.VolumePath, s.VolumeName, "config-"+serv, readinessProbe,
 				resources.Requests.Cpu, resources.Requests.Memory, resources.Limits.Cpu, resources.Limits.Memory,
 				nodeAffinity, protocol)

--- a/generator/src/pkg/model/input.go
+++ b/generator/src/pkg/model/input.go
@@ -82,6 +82,7 @@ type Service struct {
 
 type Cluster struct {
 	Cluster   string `json:"cluster"`
+	Replicas  int    `json:"replicas,omitempty"`
 	Namespace string `json:"namespace"`
 	Node      string `json:"node,omitempty"`
 }

--- a/generator/src/pkg/service/util.go
+++ b/generator/src/pkg/service/util.go
@@ -34,8 +34,6 @@ const (
 
 	Uri = "/"
 
-	ReplicaNumber = 1
-
 	RequestsCPUDefault    = "500m"
 	RequestsMemoryDefault = "256M"
 	LimitsCPUDefault      = "1000m"


### PR DESCRIPTION
Adding the replication factor for each service which could be specified by the user in each cluster.
For instance, if the user specifies:
```
...
"services": [
    {
      "name": "service1",
      "clusters": [
        {
          "cluster": "cluster-1",
          "replicas": 2,
          "namespace": "default",
          "node": "node-1"
        }
      ],
...
```
After generating such the yaml files and deploying them to the cluster, we will have:
```
 % kubectl get pods         
NAME                                         READY   STATUS    RESTARTS        AGE
service1-75576df8cd-6djv8   2/2          Running   0                         3m27s
service1-75576df8cd-kswrq   2/2.        Running   0                         3m27s

```
It closes #46 .