### PR TITLE
Implement traffic forward ratio for Go emulator

### DIFF
--- a/emulator/src/stressors/cpu.go
+++ b/emulator/src/stressors/cpu.go
@@ -34,7 +34,8 @@ func ConcatenateCPUResponses(taskResponses *MutexTaskResponses, cpuTaskResponse 
 
 	if taskResponses.CpuTask != nil {
 		for k, v := range cpuTaskResponse.Services {
-			taskResponses.CpuTask.Services[k] = v
+			uniqueKey := UniqueKey(taskResponses.CpuTask.Services, k)
+			taskResponses.CpuTask.Services[uniqueKey] = v
 		}
 	} else {
 		taskResponses.CpuTask = cpuTaskResponse

--- a/generator/src/pkg/generate/validation.go
+++ b/generator/src/pkg/generate/validation.go
@@ -222,8 +222,15 @@ func ApplyDefaults(config *model.FileConfig) {
 			if endpoint.CpuComplexity != nil && endpoint.CpuComplexity.Threads < 1 {
 				endpoint.CpuComplexity.Threads = 1
 			}
-			if endpoint.NetworkComplexity != nil && endpoint.NetworkComplexity.ForwardRequests == "" {
-				endpoint.NetworkComplexity.ForwardRequests = "synchronous"
+			if endpoint.NetworkComplexity != nil {
+				if endpoint.NetworkComplexity.ForwardRequests == "" {
+					endpoint.NetworkComplexity.ForwardRequests = "synchronous"
+				}
+				for _, calledService := range endpoint.NetworkComplexity.CalledServices {
+					if calledService.TrafficForwardRatio < 0 {
+						calledService.TrafficForwardRatio = 0
+					}
+				}
 			}
 		}
 	}

--- a/generator/src/pkg/generate/validation.go
+++ b/generator/src/pkg/generate/validation.go
@@ -227,8 +227,8 @@ func ApplyDefaults(config *model.FileConfig) {
 					endpoint.NetworkComplexity.ForwardRequests = "synchronous"
 				}
 				for _, calledService := range endpoint.NetworkComplexity.CalledServices {
-					if calledService.TrafficForwardRatio < 0 {
-						calledService.TrafficForwardRatio = 0
+					if calledService.TrafficForwardRatio < 1 {
+						calledService.TrafficForwardRatio = 1
 					}
 				}
 			}


### PR DESCRIPTION
I forgot to add this earlier. Responses are added as "endpoint", "endpoint.2", "endpoint.3", etc