### PR TITLE
Set GOMEMLIMIT in Kubernetes manifest

### DIFF
--- a/generator/src/pkg/service/util.go
+++ b/generator/src/pkg/service/util.go
@@ -24,6 +24,8 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
+
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 const (
@@ -97,12 +99,25 @@ func CreateDeployment(metadataName, selectorAppName, selectorClusterName string,
 
 	var deployment model.DeploymentInstance
 	var containerInstance model.ContainerInstance
-	var envInstance model.EnvInstance
+	var serviceEnvInstance model.EnvInstance
+	var memlimitEnvInstance model.EnvInstance
 	var containerVolume model.ContainerVolumeInstance
 	var volumeInstance model.VolumeInstance
 
-	envInstance.Name = "SERVICE_NAME"
-	envInstance.Value = metadataName
+	serviceEnvInstance.Name = "SERVICE_NAME"
+	serviceEnvInstance.Value = metadataName
+	containerInstance.Env = append(containerInstance.Env, serviceEnvInstance)
+
+	memlimitResource, _ := resource.ParseQuantity(limitMemory)
+	memlimitBytes, ok := memlimitResource.AsInt64()
+	if !ok {
+		panic(fmt.Errorf("Could not parse memory limit %s as bytes", limitMemory))
+	}
+
+	memlimitEnvInstance.Name = "GOMEMLIMIT"
+	memlimitEnvInstance.Value = fmt.Sprint(memlimitBytes)
+	containerInstance.Env = append(containerInstance.Env, memlimitEnvInstance)
+
 	volumeInstance.Name = volumeName
 	volumeInstance.ConfigMap.Name = configMapName
 
@@ -114,7 +129,6 @@ func CreateDeployment(metadataName, selectorAppName, selectorClusterName string,
 	containerInstance.Name = containerName
 	containerInstance.Image = containerImageURL
 	containerInstance.ImagePullPolicy = containerImagePolicy
-	containerInstance.Env = append(containerInstance.Env, envInstance)
 
 	if protocol == "http" {
 		containerInstance.ReadinessProbe.HttpGet.Path = "/"


### PR DESCRIPTION
It's probably a good idea to set this so that the Go garbage collector won't exceed the Kubernetes memory limit