### PR TITLE
Add a parameter for changing the base image of the application emulator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-# This is the base image for the application emulator
+# This is the source image for the application emulator
 # It contains the source code, Go compiler and protobuf compiler
 # The generator will compile a unique layered image for the current configuration
 

--- a/docs/development-environment.md
+++ b/docs/development-environment.md
@@ -41,16 +41,16 @@ cd community
 ./kind-setup-clusters.sh [number of clusters (default 2)] [config of each cluster (default kind-cluster-3-nodes.yaml)]
 ```
 
-## Build the base image
+## Build the source image
 
-The base image, containing code and compilers, needs to be built from the local source code.
+The source image, containing code and compilers, needs to be built from the local source code.
 
 ```bash
 docker build -t "$(hostname -f)/hydragen-base" .
 ```
 
 By default, HydraGen will use a release image from GitHub Packages as the base when building your image.
-To use the development base image instead set this option in the input JSON configuration:
+To use the development source image instead set this option in the input JSON configuration:
 
 ```json
 {

--- a/docs/generator-parameters.md
+++ b/docs/generator-parameters.md
@@ -15,6 +15,9 @@ At least one cluster and endpoint is required. Other sections are optional and w
 
 #### Optional attributes
 
+* **logging**: Enables logging using Elasticsearch. See [logging.md](logging.md) for more information.
+* **development**: Builds the application emulator from a local source image (`hydragen-base`) instead of the latest release image.
+* **base_image**: Specifies the base Docker image for the application emulator. For example, to use Ubuntu 20.04, set this to `ubuntu:20.04`. The default is `busybox` which provides a minimal shell and set of utilities.
 * **resources**: Resource allocation requests and limits.
 * **processes**: The maximum number of processes the service is allowed to use (`GOMAXPROCS`). If this is set to 0, the Go runtime will choose the number of processes to use. Default: 0
 * **readiness_probe**: The initial delay before readiness probe is initiated. Default: 1 second
@@ -23,6 +26,11 @@ At least one cluster and endpoint is required. Other sections are optional and w
 
 ```json
 {
+  "settings": {
+    "logging": <boolean>,
+    "development": <boolean>,
+    "base_image": "<string>"
+  },
   "services": [
     {
       "name": "<string>",

--- a/generator/Dockerfile
+++ b/generator/Dockerfile
@@ -18,6 +18,7 @@
 # The new image should be deployed on all clusters and contains generated code for all endpoints specified in the input file
 
 ARG SRCIMAGE
+ARG BASEIMAGE
 
 FROM ${SRCIMAGE} as builder
 
@@ -37,7 +38,7 @@ RUN GRPC_HEALTH_PROBE_VERSION=v0.4.19 && \
     wget -qO/usr/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
     chmod +x /usr/bin/grpc_health_probe
 
-FROM busybox
+FROM ${BASEIMAGE}
 
 # Copy final binary to /usr/bin/app-emulator
 COPY --from=builder /usr/src/emulator/app-emulator /usr/bin/app-emulator

--- a/generator/Dockerfile
+++ b/generator/Dockerfile
@@ -17,9 +17,9 @@
 # This is a layered image that builds the current source code on top of hydragen-base and copies the binary to a new image
 # The new image should be deployed on all clusters and contains generated code for all endpoints specified in the input file
 
-ARG BASE
+ARG SRCIMAGE
 
-FROM ${BASE} as builder
+FROM ${SRCIMAGE} as builder
 
 # Copy everything the application generator created
 COPY ./generated/ /usr/src/emulator/emulator/src/generated/
@@ -29,7 +29,7 @@ WORKDIR /usr/src/emulator
 # Run protobuf compiler
 RUN protoc -I/usr/src/emulator --go_out=emulator --go_opt=module=application-emulator --go-grpc_out=emulator --go-grpc_opt=module=application-emulator /usr/src/emulator/emulator/src/generated/service.proto
 # Compile the binary without cgo
-# This makes it possible to run without a base image
+# This makes it possible to run without any dependencies
 RUN CGO_ENABLED=0 go build -mod=readonly -work -ldflags "-s -w" -o app-emulator ./emulator
 
 # Install grpc_health_probe

--- a/generator/Dockerfile
+++ b/generator/Dockerfile
@@ -37,7 +37,7 @@ RUN GRPC_HEALTH_PROBE_VERSION=v0.4.19 && \
     wget -qO/usr/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
     chmod +x /usr/bin/grpc_health_probe
 
-FROM scratch
+FROM busybox
 
 # Copy final binary to /usr/bin/app-emulator
 COPY --from=builder /usr/src/emulator/app-emulator /usr/bin/app-emulator

--- a/generator/src/pkg/generate/generate.go
+++ b/generator/src/pkg/generate/generate.go
@@ -325,8 +325,15 @@ func CreateJsonInput(userConfig model.UserConfig) string {
 }
 
 func CreateDockerImage(config model.FileConfig, buildHash string) {
-	baseName := s.FormatBaseImageName(config.Settings.Development)
 	hostName := s.HostnameFQDN()
+
+	var sourceImage string
+	if config.Settings.Development {
+		sourceImage = fmt.Sprintf("%s/%s:%s", hostName, s.SourceImageName, s.SourceImageTagDev)
+	} else {
+		sourceImage = fmt.Sprintf("%s/%s:%s", s.SourceImageURLProd, s.SourceImageName, s.SourceImageTagProd)
+	}
+
 	imageName := fmt.Sprintf("%s/%s:%s", hostName, s.ImageName, buildHash)
 
 	path, _ := os.Getwd()
@@ -336,7 +343,7 @@ func CreateDockerImage(config model.FileConfig, buildHash string) {
 		"-t",
 		imageName,
 		"--build-arg",
-		"BASE=" + baseName,
+		"SRCIMAGE=" + sourceImage,
 		path,
 	}
 

--- a/generator/src/pkg/generate/generate.go
+++ b/generator/src/pkg/generate/generate.go
@@ -344,6 +344,8 @@ func CreateDockerImage(config model.FileConfig, buildHash string) {
 		imageName,
 		"--build-arg",
 		"SRCIMAGE=" + sourceImage,
+		"--build-arg",
+		"BASEIMAGE=" + config.Settings.BaseImage,
 		path,
 	}
 

--- a/generator/src/pkg/generate/validation.go
+++ b/generator/src/pkg/generate/validation.go
@@ -186,6 +186,10 @@ func ValidateFileConfig(config *model.FileConfig) error {
 
 // Applies default values to input JSON
 func ApplyDefaults(config *model.FileConfig) {
+	if config.Settings.BaseImage == "" {
+		config.Settings.BaseImage = s.BaseImageDefault
+	}
+
 	for i := range config.Services {
 		service := &config.Services[i]
 

--- a/generator/src/pkg/service/util.go
+++ b/generator/src/pkg/service/util.go
@@ -32,11 +32,11 @@ const (
 	VolumeName = "config-data-volume"
 	VolumePath = "/usr/src/emulator/config"
 
-	BaseImageURLProd = "ghcr.io/ericssonresearch/cloud-native-app-simulator"
-	BaseImageName    = "hydragen-base"
+	SourceImageURLProd = "ghcr.io/ericssonresearch/cloud-native-app-simulator"
+	SourceImageName    = "hydragen-base"
 	// TODO: Update the version here once everything is released
-	BaseImageTagProd = "v4.0.0"
-	BaseImageTagDev  = "latest"
+	SourceImageTagProd = "v4.0.0"
+	SourceImageTagDev  = "latest"
 
 	ContainerName   = "app"
 	ImageName       = "hydragen-emulator"
@@ -82,15 +82,6 @@ func HostnameFQDN() string {
 	}
 
 	return strings.TrimSpace(out.String())
-}
-
-func FormatBaseImageName(development bool) string {
-	if development {
-		hostName := HostnameFQDN()
-		return fmt.Sprintf("%s/%s:%s", hostName, BaseImageName, BaseImageTagDev)
-	} else {
-		return fmt.Sprintf("%s/%s:%s", BaseImageURLProd, BaseImageName, BaseImageTagProd)
-	}
 }
 
 func CreateDeployment(metadataName, selectorAppName, selectorClusterName string, numberOfReplicas int,

--- a/generator/src/pkg/service/util.go
+++ b/generator/src/pkg/service/util.go
@@ -38,9 +38,11 @@ const (
 	SourceImageTagProd = "v4.0.0"
 	SourceImageTagDev  = "latest"
 
-	ContainerName   = "app"
-	ImageName       = "hydragen-emulator"
-	ImagePullPolicy = "Never"
+	BaseImageDefault = "busybox"
+	ImageName        = "hydragen-emulator"
+	ImagePullPolicy  = "Never"
+
+	ContainerName = "app"
 
 	DefaultExtPort  = 80
 	DefaultPort     = 5000

--- a/model/input.go
+++ b/model/input.go
@@ -88,8 +88,9 @@ type ClusterLatency struct {
 }
 
 type Setting struct {
-	Logging     bool `json:"logging"`
-	Development bool `json:"development"`
+	Logging     bool   `json:"logging"`
+	Development bool   `json:"development"`
+	BaseImage   string `json:"base_image"`
 }
 
 type FileConfig struct {


### PR DESCRIPTION
The default is set to BusyBox which provides a minimal shell (`/bin/sh`) and utilities without noticeably increasing image size.

`FROM scratch`: 22 MB
`FROM busybox`: 26 MB (+18%)
`FROM ubuntu`: 100 MB (+350%)