### PR TITLE
Fix concurrency crash

### DIFF
--- a/emulator/src/client/restful.go
+++ b/emulator/src/client/restful.go
@@ -50,8 +50,6 @@ func POST(service, endpoint string, port int, payload string, headers http.Heade
 
 	request, _ := http.NewRequest(http.MethodPost, url, bytes.NewReader(postData))
 
-	// Override the content type
-	headers.Set("Content-Type", "application/json")
 	// Forward any other headers set by the user
 	for key, values := range headers {
 		for _, value := range values {

--- a/emulator/src/stressors/forward.go
+++ b/emulator/src/stressors/forward.go
@@ -47,6 +47,9 @@ func ExtractHeaders(request any) http.Header {
 		}
 	}
 
+	// Override the content type
+	forwardHeaders.Set("Content-Type", "application/json")
+
 	return forwardHeaders
 }
 


### PR DESCRIPTION
Close #90 

The `forwardHeaders` is shared among all go routines making parallel http requests. The line in `clientPost()` modifying this shared `forwardHeaders` will cause the concurrency bug. Although I'm not pretty sure about the meaning of this `headers.Set()`, moving it shouldn't break anything since each go routine performs the same operation.

Test: re-run the experiments in issue #90. The service wont crash for not only the simple `for` loop, but also under traffic of 750 requests/s for 30s generated by wrk2 generator.